### PR TITLE
Fix tokenizer splitting bug in data_utils

### DIFF
--- a/data_utils.py
+++ b/data_utils.py
@@ -8,7 +8,8 @@ import numpy as np
 
 PAD_TOKEN = '_PAD'
 PAD_ID = 0
-SPLIT_RE = re.compile('(\W+)?')
+# split on any non-word characters while keeping punctuation
+SPLIT_RE = re.compile(r'(\W+)')
 
 def load_task(data_dir, task_id, only_supporting=False):
     """


### PR DESCRIPTION
## Summary
- regex wrongly split every character into tokens
- fix tokenizer regex to keep punctuation while splitting on non-word characters

## Testing
- `python -m py_compile data_utils.py dataset.py model.py run_babi.py seed.py`